### PR TITLE
climate 지원

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,48 @@ devices:
           - attribute: contact
             name: cooler contact
             parent_entity_id: parent_entity_id
+  - device_id: 00000000-0000-0000-0000-000000000000
+    climates:
+      - name: Bedroom Aircon
+        capabilities:
+          - capability: switch
+            component: "1"
+            commands:
+              - on_command: "on"
+                off_command: "off"
+                attribute: switch
+                on_state: ["on"]
+                argument:
+                  "on": []
+                  "off": []
+          - capability: airConditionerMode
+            component: "1"
+            options:
+              attribute: supportedAcModes
+            commands:
+              - command: setAirConditionerMode
+                attribute: airConditionerMode
+                argument: []
+          - capability: airConditionerFanMode
+            component: "1"
+            options:
+              attribute: supportedAcFanModes
+            commands:
+              - command: setFanMode
+                attribute: fanMode
+                argument: []
+          - capability: thermostatCoolingSetpoint
+            component: "1"
+            min: 22
+            max: 28
+            step: 1
+            commands:
+              - command: setCoolingSetpoint
+                attribute: coolingSetpoint
+          - capability: temperatureMeasurement
+            component: "1"
+            attributes:
+              - attribute: temperature
 
 ignore_platforms:
   - scene
@@ -227,3 +269,4 @@ default_entity_id_format: "st_custom_%{device_id}_%{label}_%{component}_%{capabi
 - select
 - button
 - text
+- climate

--- a/README.md
+++ b/README.md
@@ -250,6 +250,15 @@ devices:
 ignore_platforms:
   - scene
 
+ignore_capabilities:
+  - alarm
+  - mediaInputSource
+  - mediaPlaybackRepeat
+  - mediaPlaybackShuffle
+  - thermostatHeatingSetpoint
+  - thermostatMode
+  - thermostatOperatingState
+
 enable_syntax_property: false
 
 default_entity_id_format: "st_custom_%{device_id}_%{label}_%{component}_%{capability}_%{attribute}_%{command}_%{name}"

--- a/custom_components/smartthings_customize/__init__.py
+++ b/custom_components/smartthings_customize/__init__.py
@@ -202,19 +202,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             )
         return False
 
-    entity_registry = homeassistant.helpers.entity_registry.async_get(
-            hass)
-    entities = homeassistant.helpers.entity_registry.async_entries_for_config_entry(
-        entity_registry, entry.entry_id)
-    for e in entities:
-        entity_registry.async_remove(e.entity_id)
+    # entity_registry = homeassistant.helpers.entity_registry.async_get(
+    #         hass)
+    # entities = homeassistant.helpers.entity_registry.async_entries_for_config_entry(
+    #     entity_registry, entry.entry_id)
+    # for e in entities:
+    #     entity_registry.async_remove(e.entity_id)
 
-    device_registry = homeassistant.helpers.device_registry.async_get(hass)
-    devices = homeassistant.helpers.device_registry.async_entries_for_config_entry(
-    device_registry, entry.entry_id)
-    for d in devices:
-        if DOMAIN in d.identifiers:
-            device_registry.async_remove_device(d.id)
+    # device_registry = homeassistant.helpers.device_registry.async_get(hass)
+    # devices = homeassistant.helpers.device_registry.async_entries_for_config_entry(
+    # device_registry, entry.entry_id)
+    # for d in devices:
+    #     if DOMAIN in d.identifiers:
+    #         device_registry.async_remove_device(d.id)
 
     #PLATFORMS.different_update(SettingManager.ignore_platforms())
     await hass.config_entries.async_forward_entry_setups(entry, SettingManager().get_enable_platforms())

--- a/custom_components/smartthings_customize/climate.py
+++ b/custom_components/smartthings_customize/climate.py
@@ -359,7 +359,10 @@ class SmartThingsClimate_custom(SmartThingsEntity, ClimateEntity):
     @property
     def temperature_unit(self):
         """Return the unit of measurement."""
-        return UNIT_MAP.get(self._device.status._components[self._temperatureMeasurement.get("component")].attributes[Attribute.temperature].unit)
+        if self._thermostatCoolingSetpoint.get("component") == "main":
+            return UNIT_MAP.get(self._device.status.attributes[Attribute.temperature].unit)
+        else:
+            return UNIT_MAP.get(self._device.status._components[self._temperatureMeasurement.get("component")].attributes[Attribute.temperature].unit)
 
 
 def get_capabilities(capabilities: Sequence[str]) -> Sequence[str] | None:

--- a/custom_components/smartthings_customize/climate.py
+++ b/custom_components/smartthings_customize/climate.py
@@ -111,11 +111,8 @@ async def async_setup_entry(
             if custom_platform not in device_setting: 
                 continue
         for device in broker.devices.values():
-            # if SettingManager.is_allow_device(device.device_id) == False:
-            #     continue
             if device.device_id == device_setting["device_id"]:
                 for dev in device_setting[custom_platform]:
-                    # _LOGGER.warning("device_id : %s => %s", device_setting["device_id"], dev)
                     climate = {
                         cap.get("capability"): cap for cap in dev.get("capabilities")
                     }
@@ -139,7 +136,6 @@ class SmartThingsClimate_custom(SmartThingsEntity, ClimateEntity):
     def __init__(self, device, name:str, switch, airConditionerMode, airConditionerFanMode, thermostatCoolingSetpoint, temperatureMeasurement) -> None:
         super().__init__(device)
         self._hvac_modes = None
-        self._device = device
         self._name = name
         self._switch = switch
         self._airConditionerMode = airConditionerMode

--- a/custom_components/smartthings_customize/climate.py
+++ b/custom_components/smartthings_customize/climate.py
@@ -355,7 +355,7 @@ class SmartThingsClimate_custom(SmartThingsEntity, ClimateEntity):
     @property
     def temperature_unit(self):
         """Return the unit of measurement."""
-        if self._thermostatCoolingSetpoint.get("component") == "main":
+        if self._temperatureMeasurement.get("component") == "main":
             return UNIT_MAP.get(self._device.status.attributes[Attribute.temperature].unit)
         else:
             return UNIT_MAP.get(self._device.status._components[self._temperatureMeasurement.get("component")].attributes[Attribute.temperature].unit)

--- a/custom_components/smartthings_customize/climate.py
+++ b/custom_components/smartthings_customize/climate.py
@@ -111,8 +111,8 @@ async def async_setup_entry(
             if custom_platform not in device_setting: 
                 continue
         for device in broker.devices.values():
-            if SettingManager.is_allow_device(device.device_id) == False:
-                continue
+            # if SettingManager.is_allow_device(device.device_id) == False:
+            #     continue
             if device.device_id == device_setting["device_id"]:
                 for dev in device_setting[custom_platform]:
                     # _LOGGER.warning("device_id : %s => %s", device_setting["device_id"], dev)

--- a/custom_components/smartthings_customize/climate.py
+++ b/custom_components/smartthings_customize/climate.py
@@ -24,8 +24,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import SmartThingsEntity, SmartThingsEntity_custom
-from .const import DATA_BROKERS, DOMAIN
-from .common import SettingManager
+from .const import *
+from .common import *
 
 ATTR_OPERATION_STATE = "operation_state"
 MODE_TO_STATE = {
@@ -105,32 +105,261 @@ async def async_setup_entry(
             else:
                 entities.append(SmartThingsThermostat(device))
 
-
-    # broker = hass.data[DOMAIN][DATA_BROKERS][config_entry.entry_id]
-    # entities = []
-    # settings = SettingManager.get_capa_settings(broker, "climates")
-    # _LOGGER.debug("climate settings : " + str(settings))
-    # # Climate 중에 device 가 같고, component 가 같은것들 끼리 모은다
-    # #for s in settings:
-    
-    #     # entities.append(SmartThingsClimate_custom(hass,
-    #     #                                             s[0],
-    #     #                                             s[2].get("name"),
-    #     #                                             s[1].get("component"),
-    #     #                                             s[2].get("parent_entity_id"),
-    #     #                                             s[2].get("air_conditioner_mode"),
-
-    #     # ))
-
+    custom_platform = CUSTOM_PLATFORMS[Platform.CLIMATE]
+    for device_setting in SettingManager.get_device_setting():
+        if device_setting["device_id"] in broker.devices:
+            if custom_platform not in device_setting: 
+                continue
+        for device in broker.devices.values():
+            if SettingManager.is_allow_device(device.device_id) == False:
+                continue
+            if device.device_id == device_setting["device_id"]:
+                for dev in device_setting[custom_platform]:
+                    # _LOGGER.warning("device_id : %s => %s", device_setting["device_id"], dev)
+                    climate = {
+                        cap.get("capability"): cap for cap in dev.get("capabilities")
+                    }
+                    # _LOGGER.warning("climate_capabilities : %s", climate)
+                    entities.append(
+                        SmartThingsClimate_custom(
+                            device,
+                            dev.get("name"),
+                            climate.get("switch"),
+                            climate.get("airConditionerMode"),
+                            climate.get("airConditionerFanMode"),
+                            climate.get("thermostatCoolingSetpoint"),
+                            climate.get("temperatureMeasurement")
+                        )
+                    )
     async_add_entities(entities, True)
 
-class SmartThingsClimate_custom(SmartThingsEntity_custom, ClimateEntity):
-    def __init__(self, hass, device, name:str, component, capability: str, command:str, argument:str, parent_entity_id) -> None:
-        super().__init__(hass, "button", device, name, component, capability, None, command, argument, parent_entity_id )
-    
+
+class SmartThingsClimate_custom(SmartThingsEntity, ClimateEntity):
+    """Define a SmartThings Air Conditioner."""
+    def __init__(self, device, name:str, switch, airConditionerMode, airConditionerFanMode, thermostatCoolingSetpoint, temperatureMeasurement) -> None:
+        super().__init__(device)
+        self._hvac_modes = None
+        self._device = device
+        self._name = name
+        self._switch = switch
+        self._airConditionerMode = airConditionerMode
+        self._airConditionerFanMode = airConditionerFanMode
+        self._thermostatCoolingSetpoint = thermostatCoolingSetpoint
+        self._temperatureMeasurement = temperatureMeasurement
+
+    _attr_supported_features = (
+        ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE
+    )
+
     @property
-    def temperature_unit(self) -> str:
-        return super().temperature_unit
+    def name(self) -> str:
+        return f"{self._name}"
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._device.device_id}.{self._name}"
+
+    async def async_set_fan_mode(self, fan_mode: str) -> None:
+        # """Set new target fan mode."""
+        if self._airConditionerFanMode.get("component") == "main":
+            await self._device.set_fan_mode(fan_mode, set_status=True)
+            # State is set optimistically in the command above, therefore update
+            # the entity state ahead of receiving the confirming push updates
+        else:
+            arg = []
+            arg.append(fan_mode)
+            await self._device.command(self._airConditionerFanMode.get("component"), self._airConditionerFanMode.get("capability"), self._airConditionerFanMode.get("commands")[0]["command"], arg)
+        self.async_write_ha_state()
+
+    async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        """Set new target operation mode."""
+        if hvac_mode == HVACMode.OFF:
+            await self.async_turn_off()
+            return
+        tasks = []
+        # Turn on the device if it's off before setting mode.
+        if self._switch.get("component") == "main":
+            if not self._device.status.switch:
+                tasks.append(self._device.switch_on(set_status=True))
+            tasks.append(
+                self._device.set_air_conditioner_mode(
+                    STATE_TO_AC_MODE[hvac_mode], set_status=True
+                )
+            )
+        else:
+            value = self._device.status._components[self._switch.get("component")].attributes.get(self._switch.get("commands")[0]["attribute"]).value
+            if not value in self._switch.get("commands")[0]["on_state"]:
+                tasks.append(self._device.command(self._switch.get("component"), self._switch.get("capability"), self._switch.get("commands")[0]["on_command"], self._switch.get("commands")[0]["argument"]["on"]))
+            arg = []
+            arg.append(STATE_TO_AC_MODE[hvac_mode])
+            tasks.append(
+                self._device.command(self._airConditionerMode.get("component"), self._airConditionerMode.get("capability"), self._airConditionerMode.get("commands")[0]["command"], arg)
+            )
+        await asyncio.gather(*tasks)
+        # State is set optimistically in the command above, therefore update
+        # the entity state ahead of receiving the confirming push updates
+        self.async_write_ha_state()
+
+    async def async_set_temperature(self, **kwargs: Any) -> None:
+        """Set new target temperature."""
+        tasks = []
+        # operation mode
+        if operation_mode := kwargs.get(ATTR_HVAC_MODE):
+            if self._switch.get("component") == "main":
+                if operation_mode == HVACMode.OFF:
+                    tasks.append(self._device.switch_off(set_status=True))
+                else:
+                    if not self._device.status.switch:
+                        tasks.append(self._device.switch_on(set_status=True))
+                    tasks.append(self.async_set_hvac_mode(operation_mode))
+            else:
+                if operation_mode == HVACMode.OFF:
+                    tasks.append(self._device.command(self._switch.get("component"), self._switch.get("capability"), self._switch.get("commands")[0]["on_command"], self._switch.get("commands")[0]["argument"]["off"]))
+                else:
+                    value = self._device.status._components[self._switch.get("component")].attributes.get(self._switch.get("commands")[0]["attribute"]).value
+                    if not value in self._switch.get("commands")[0]["on_state"]:
+                        tasks.append(self._device.command(self._switch.get("component"), self._switch.get("capability"), self._switch.get("commands")[0]["on_command"], self._switch.get("commands")[0]["argument"]["on"]))
+                    tasks.append(self.async_set_hvac_mode(operation_mode))
+        # temperature
+        if self._thermostatCoolingSetpoint.get("component") == "main":
+            tasks.append(
+                self._device.set_cooling_setpoint(kwargs[ATTR_TEMPERATURE], set_status=True)
+            )
+        else:
+            arg = []
+            arg.append(kwargs[ATTR_TEMPERATURE])
+            tasks.append(
+                self._device.command(self._thermostatCoolingSetpoint.get("component"), self._thermostatCoolingSetpoint.get("capability"), self._thermostatCoolingSetpoint.get("commands")[0]["command"], arg)
+            )
+        await asyncio.gather(*tasks)
+        # State is set optimistically in the command above, therefore update
+        # the entity state ahead of receiving the confirming push updates
+        self.async_write_ha_state()
+
+    async def async_turn_on(self) -> None:
+        """Turn device on."""
+        if self._switch.get("component") == "main":
+            await self._device.switch_on(set_status=True)
+        else:
+            await self._device.command(self._switch.get("component"), self._switch.get("capability"), self._switch.get("commands")[0]["on_command"], self._switch.get("commands")[0]["argument"]["on"])
+        # State is set optimistically in the command above, therefore update
+        # the entity state ahead of receiving the confirming push updates
+        self.async_write_ha_state()
+
+    async def async_turn_off(self) -> None:
+        """Turn device off."""
+        if self._switch.get("component") == "main":
+            await self._device.switch_off(set_status=True)
+        else:
+            await self._device.command(self._switch.get("component"), self._switch.get("capability"), self._switch.get("commands")[0]["off_command"], self._switch.get("commands")[0]["argument"]["off"])
+        # State is set optimistically in the command above, therefore update
+        # the entity state ahead of receiving the confirming push updates
+        self.async_write_ha_state()
+
+    async def async_update(self) -> None:
+        """Update the calculated fields of the AC."""
+        modes = {HVACMode.OFF}
+        if self._airConditionerMode.get("component") == "main":
+            for mode in self._device.status.supported_ac_modes:
+                if (state := AC_MODE_TO_STATE.get(mode)) is not None:
+                    modes.add(state)
+                else:
+                    _LOGGER.debug(
+                        "Device %s (%s) returned an invalid supported AC mode: %s",
+                        self._device.label,
+                        self._device.device_id,
+                        mode,
+                    )
+        else:
+            for mode in self._device.status._components[self._airConditionerMode.get("component")].attributes.get(self._airConditionerMode.get("options")["attribute"]).value:
+                if (state := AC_MODE_TO_STATE.get(mode)) is not None:
+                    modes.add(state)
+                else:
+                    _LOGGER.debug(
+                        "Device %s (%s) returned an invalid supported AC mode: %s",
+                        self._device.label,
+                        self._device.device_id,
+                        mode,
+                    )
+        self._hvac_modes = list(modes)
+
+    @property
+    def current_temperature(self):
+        """Return the current temperature."""
+        if self._temperatureMeasurement.get("component") == "main":
+            return self._device.status.temperature
+        else:
+            return self._device.status._components[self._temperatureMeasurement.get("component")].attributes.get(self._temperatureMeasurement.get("attributes")[0]["attribute"]).value
+
+    @property
+    def extra_state_attributes(self):
+        """Return device specific state attributes.
+
+        Include attributes from the Demand Response Load Control (drlc)
+        and Power Consumption capabilities.
+        """
+        attributes = [
+            "drlc_status_duration",
+            "drlc_status_level",
+            "drlc_status_start",
+            "drlc_status_override",
+        ]
+        state_attributes = {}
+        for attribute in attributes:
+            value = getattr(self._device.status, attribute)
+            if value is not None:
+                state_attributes[attribute] = value
+        state_attributes["min_temp"] = self._thermostatCoolingSetpoint.get("min")
+        state_attributes["max_temp"] = self._thermostatCoolingSetpoint.get("max")
+        state_attributes["target_temp_step"] = self._thermostatCoolingSetpoint.get("step")
+        return state_attributes
+
+    @property
+    def fan_mode(self):
+        """Return the fan setting."""
+        if self._airConditionerFanMode.get("component") == "main":
+            return self._device.status.fan_mode
+        else:
+            return self._device.status._components[self._airConditionerFanMode.get("component")].attributes.get(self._airConditionerFanMode.get("commands")[0]["attribute"]).value
+
+    @property
+    def fan_modes(self):
+        """Return the list of available fan modes."""
+        if self._airConditionerFanMode.get("component") == "main":
+            return self._device.status.supported_ac_fan_modes
+        else:
+            return self._device.status._components[self._airConditionerFanMode.get("component")].attributes.get(self._airConditionerFanMode.get("options")["attribute"]).value
+
+    @property
+    def hvac_mode(self) -> HVACMode | None:
+        """Return current operation ie. heat, cool, idle."""
+        if self._switch.get("component") == "main":
+            if not self._device.status.switch:
+                return HVACMode.OFF
+            return AC_MODE_TO_STATE.get(self._device.status.air_conditioner_mode)
+        else:
+            value = self._device.status._components[self._switch.get("component")].attributes.get(self._switch.get("commands")[0]["attribute"]).value
+            if not value in self._switch.get("commands")[0]["on_state"]:
+                return HVACMode.OFF
+            return AC_MODE_TO_STATE.get(self._device.status._components[self._airConditionerMode.get("component")].attributes.get(self._airConditionerMode.get("commands")[0]["attribute"]).value)
+
+    @property
+    def hvac_modes(self) -> list[HVACMode]:
+        """Return the list of available operation modes."""
+        return self._hvac_modes
+
+    @property
+    def target_temperature(self):
+        """Return the temperature we try to reach."""
+        if self._thermostatCoolingSetpoint.get("component") == "main":
+            return self._device.status.cooling_setpoint
+        else:
+            return self._device.status._components[self._thermostatCoolingSetpoint.get("component")].attributes.get(self._thermostatCoolingSetpoint.get("commands")[0]["attribute"]).value
+
+    @property
+    def temperature_unit(self):
+        """Return the unit of measurement."""
+        return UNIT_MAP.get(self._device.status._components[self._temperatureMeasurement.get("component")].attributes[Attribute.temperature].unit)
 
 
 def get_capabilities(capabilities: Sequence[str]) -> Sequence[str] | None:

--- a/custom_components/smartthings_customize/common.py
+++ b/custom_components/smartthings_customize/common.py
@@ -85,8 +85,13 @@ class SettingManager(object):
                 for setting in settings:
                     for platform in CUSTOM_PLATFORMS.values():
                         if setting.get(platform):
-                            for cap in setting[platform]:
-                                capabilities.append(cap.get("capability"))
+                            if platform == CUSTOM_PLATFORMS[Platform.CLIMATE]:
+                                for dev in setting[platform]:
+                                    for cap in dev["capabilities"]:
+                                        capabilities.append(cap.get("capability"))
+                            else:
+                                for cap in setting[platform]:
+                                    capabilities.append(cap.get("capability"))
         except Exception as e:
             _LOGGER.debug("get_capabilities error : " + str(e))
             pass

--- a/custom_components/smartthings_customize/common.py
+++ b/custom_components/smartthings_customize/common.py
@@ -207,3 +207,12 @@ class SettingManager(object):
         except Exception as e:
             _LOGGER.debug("ignore_platforms error : " + str(e))
             return []
+
+    @staticmethod
+    def ignore_capabilities():
+        try:
+            mgr = SettingManager()
+            return mgr._settings.get("ignore_capabilities")
+        except Exception as e:
+            _LOGGER.debug("ignore_capabilities error : " + str(e))
+            return []

--- a/custom_components/smartthings_customize/const.py
+++ b/custom_components/smartthings_customize/const.py
@@ -71,6 +71,7 @@ CUSTOM_PLATFORMS = {
     Platform.SELECT: "selects",
     Platform.BUTTON: "buttons",
     Platform.TEXT: "texts",
+    Platform.CLIMATE: "climates",
 }
 
 IGNORED_CAPABILITIES = [

--- a/custom_components/smartthings_customize/example/example_1.yaml
+++ b/custom_components/smartthings_customize/example/example_1.yaml
@@ -163,6 +163,48 @@ devices:
           - attribute: contact
             name: cooler contact
             parent_entity_id: parent_entity_id
+  - device_id: 00000000-0000-0000-0000-000000000000
+    climates:
+      - name: Bedroom Aircon
+        capabilities:
+          - capability: switch
+            component: "1"
+            commands:
+              - on_command: "on"
+                off_command: "off"
+                attribute: switch
+                on_state: ["on"]
+                argument:
+                  "on": []
+                  "off": []
+          - capability: airConditionerMode
+            component: "1"
+            options:
+              attribute: supportedAcModes
+            commands:
+              - command: setAirConditionerMode
+                attribute: airConditionerMode
+                argument: []
+          - capability: airConditionerFanMode
+            component: "1"
+            options:
+              attribute: supportedAcFanModes
+            commands:
+              - command: setFanMode
+                attribute: fanMode
+                argument: []
+          - capability: thermostatCoolingSetpoint
+            component: "1"
+            min: 22
+            max: 28
+            step: 1
+            commands:
+              - command: setCoolingSetpoint
+                attribute: coolingSetpoint
+          - capability: temperatureMeasurement
+            component: "1"
+            attributes:
+              - attribute: temperature
 
 ignore_platforms:
   - scene

--- a/custom_components/smartthings_customize/example/example_1.yaml
+++ b/custom_components/smartthings_customize/example/example_1.yaml
@@ -209,6 +209,15 @@ devices:
 ignore_platforms:
   - scene
 
+ignore_capabilities:
+  - alarm
+  - mediaInputSource
+  - mediaPlaybackRepeat
+  - mediaPlaybackShuffle
+  - thermostatHeatingSetpoint
+  - thermostatMode
+  - thermostatOperatingState
+
 enable_syntax_property: false
 
 default_entity_id_format: "st_custom_%{device_id}_%{label}_%{component}_%{capability}_%{attribute}_%{command}_%{name}"

--- a/custom_components/smartthings_customize/manifest.json
+++ b/custom_components/smartthings_customize/manifest.json
@@ -12,5 +12,5 @@
     "@oukene"
   ],
   "iot_class": "cloud_push",
-  "version": "1.4.0"
+  "version": "1.6.0"
 }

--- a/custom_components/smartthings_customize/sensor.py
+++ b/custom_components/smartthings_customize/sensor.py
@@ -575,7 +575,11 @@ async def async_setup_entry(
             #_LOGGER.error("capability : " + str(broker.get_assigned(device.device_id, "sensor")))
             if SettingManager.is_allow_device(device.device_id) == False:
                 continue
+            ignore_capa = SettingManager().ignore_capabilities()
             for capability in broker.get_assigned(device.device_id, Platform.SENSOR):
+                if ignore_capa != None:
+                    if capability in ignore_capa:
+                        continue
                 if capability == Capability.three_axis:
                     entities.extend(
                         [

--- a/custom_components/smartthings_customize/smartapp.py
+++ b/custom_components/smartthings_customize/smartapp.py
@@ -390,6 +390,10 @@ async def smartapp_sync_subscriptions(
     CAPABILITIES.extend(extend_capa)
     for device in devices:
         capabilities.update(device.capabilities)
+    # Remove ignore capabilities
+    ignore_capa = SettingManager().ignore_capabilities()
+    if ignore_capa != None:
+        capabilities.difference_update(ignore_capa)
     # Remove items not defined in the library
     capabilities.intersection_update(CAPABILITIES)
     # Remove unused capabilities


### PR DESCRIPTION
에어컨만 지원하도록 했습니다.
그래서 아래의 5가지 캐퍼빌리티는 반드시 존재해야 합니다.
- switch
- airConditionerMode
- airConditionerFanMode
- thermostatCoolingSetpoint
- temperatureMeasurement

name이나 unique_id관련 템플릿은 적용되어 있지 않습니다.

설정 예)

  - device_id: 00000000-0000-0000-0000-000000000000
    climates:
      - name: Bedroom Aircon
        capabilities:
          - capability: switch
            component: "1"
            commands:
              - on_command: "on"
                off_command: "off"
                attribute: switch
                on_state: ["on"]
                argument:
                  "on": []
                  "off": []
          - capability: airConditionerMode
            component: "1"
            options:
              attribute: supportedAcModes
            commands:
              - command: setAirConditionerMode
                attribute: airConditionerMode
                argument: []
          - capability: airConditionerFanMode
            component: "1"
            options:
              attribute: supportedAcFanModes
            commands:
              - command: setFanMode
                attribute: fanMode
                argument: []
          - capability: thermostatCoolingSetpoint
            component: "1"
            min: 22
            max: 28
            step: 1
            commands:
              - command: setCoolingSetpoint
                attribute: coolingSetpoint
          - capability: temperatureMeasurement
            component: "1"
            attributes:
              - attribute: temperature