### PR TITLE
entity_id 수정후 리로드시 리셋되는 문제

### DIFF
--- a/custom_components/smartthings_customize/__init__.py
+++ b/custom_components/smartthings_customize/__init__.py
@@ -203,20 +203,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             )
         return False
 
-    if SettingManager.always_reset_entity():
-        entity_registry = homeassistant.helpers.entity_registry.async_get(
-                hass)
-        entities = homeassistant.helpers.entity_registry.async_entries_for_config_entry(
-            entity_registry, entry.entry_id)
-        for e in entities:
-            entity_registry.async_remove(e.entity_id)
+    # entity_registry = homeassistant.helpers.entity_registry.async_get(
+    #         hass)
+    # entities = homeassistant.helpers.entity_registry.async_entries_for_config_entry(
+    #     entity_registry, entry.entry_id)
+    # for e in entities:
+    #     entity_registry.async_remove(e.entity_id)
 
-        device_registry = homeassistant.helpers.device_registry.async_get(hass)
-        devices = homeassistant.helpers.device_registry.async_entries_for_config_entry(
-        device_registry, entry.entry_id)
-        for d in devices:
-            if DOMAIN in d.identifiers:
-                device_registry.async_remove_device(d.id)
+    # device_registry = homeassistant.helpers.device_registry.async_get(hass)
+    # devices = homeassistant.helpers.device_registry.async_entries_for_config_entry(
+    # device_registry, entry.entry_id)
+    # for d in devices:
+    #     if DOMAIN in d.identifiers:
+    #         device_registry.async_remove_device(d.id)
 
     hass.data[DOMAIN]["listener"] = []
 


### PR DESCRIPTION
모든 기기와 Entity들을 삭제한 후에 다시 생성하기 때문에
사용자가 수정한 entity_id가 원해대로 변경되는 문제