### PR TITLE
hvac_modes 사용자설정

### DIFF
--- a/custom_components/smartthings_customize/climate_custom.py
+++ b/custom_components/smartthings_customize/climate_custom.py
@@ -104,9 +104,9 @@ class SmartThingsClimate_custom(SmartThingsEntity_custom, ClimateEntity, ExtraCa
 
     @property
     def hvac_modes(self) -> list[HVACMode]:
-        options = ["off"]
-        options.extend(self.get_extra_capa_attr_value(ATTR_MODE, "options"))
-        return options
+        hvac_modes = []
+        hvac_modes.extend(self.get_extra_capa_attr_value(ATTR_MODE, "hvac_modes"))
+        return hvac_modes
 
     @property
     def fan_mode(self) -> str | None:


### PR DESCRIPTION
supportedAcModes와 hvac_modes는 서로 다릅니다.
에어컨에서는 supportedAcModes가 사용되고 HA의 climate UI에서는 hvac_modes가 사용됩니다.
이것을 서로 변환시켜주어야 합니다.
참고로 hvac_modes에는 off, heat, cool, heat_cool, auto, dry, fan_only만 사용할 수 있습니다.
따라서 아래의 내용을 추가로 설정해 주어야 합니다.
예를 들어, fan_only를 선택하였을 경우에 삼성에어컨에서는 wind 명령어가 적용이 됩니다.
                hvac_modes:
                  ["auto", "cool", "dry", "fan_only", "off"]

이것을 서로 변환시켜주는 사용자설정도 필요해 보입니다.