### PR TITLE
unique_id와 entity_id를 다르게 구성

### DIFF
--- a/custom_components/smartthings_customize/__init__.py
+++ b/custom_components/smartthings_customize/__init__.py
@@ -536,13 +536,15 @@ class SmartThingsEntity_custom(Entity):
         self._device_info = []
         self._platform = platform
 
+        t = temp(DEFAULT_ENTITY_ID_FORMAT)
+        entity_id_format = t.substitute(device_id=self._device.device_id, label=self._device.label, component=self._component, capability=self._capability, attribute=self._attribute, command=self._command, name=self._name)
+        self._unique_id = async_generate_entity_id(platform + ".{}", entity_id_format, hass=hass)
+
         entity_id_format = SettingManager.default_entity_id_format() if SettingManager.default_entity_id_format() != None else DEFAULT_ENTITY_ID_FORMAT
         if setting[1].get(CONF_ENTITY_ID_FORMAT) != None:
             entity_id_format = setting[1].get(CONF_ENTITY_ID_FORMAT)
-
         t = temp(entity_id_format)
         entity_id_format = t.substitute(device_id=self._device.device_id, label=self._device.label, component=self._component, capability=self._capability, attribute=self._attribute, command=self._command, name=self._name)
-
         self.entity_id = async_generate_entity_id(platform + ".{}", entity_id_format, hass=hass)
         
         _LOGGER.debug("create entity id : %s", self.entity_id)

--- a/custom_components/smartthings_customize/__init__.py
+++ b/custom_components/smartthings_customize/__init__.py
@@ -548,7 +548,6 @@ class SmartThingsEntity_custom(Entity):
         self.entity_id = async_generate_entity_id(platform + ".{}", entity_id_format, hass=hass)
         
         _LOGGER.debug("create entity id : %s", self.entity_id)
-        self._unique_id = self.entity_id
         
         registry = er.async_get(hass)
         


### PR DESCRIPTION
init.py 에서 unique_id와 entity_id를 다르게 구성했습니다.
unique_id는 복잡한 기본설정으로 하고 entity_id는 기존처럼 사용자정의로 합니다. 이렇게 하는 이유는 always_reset_entity: false로 설정한 경우이거나
통합구성요소에서 "다시 읽어오기"를 하더라도 기존에 존재하는 동일한 unique_id의
entity를 다시 생성하지 않기 위해서입니다.

이렇게 하면 사용자가 각각의 구성요소 설정화면을 통하여
구성요소 ID를 수정하거나 이름을 수정한 후에 다시 읽어오더라도
변경된 사항이 리셋되지 않고 동일한 entity를 다시 만들지 않습니다.

따라서 리셋이 꼭 필요한 경우에만
always_reset_entity: true
이렇게 설정하고 재시작하거나 다시읽어오기를 수행합니다.